### PR TITLE
maildir: take maildir flags into account

### DIFF
--- a/notmuch_gmail/maildir.py
+++ b/notmuch_gmail/maildir.py
@@ -47,7 +47,7 @@ class Maildir(object):
     def all_messages(self):
         return self._search_notmuch('path:**')[0]
 
-    GMAIL_MESSAGE_RE = re.compile(r'^gmail\.([0-9a-f]+):2,$')
+    GMAIL_MESSAGE_RE = re.compile(r'^gmail\.([0-9a-f]+):2,[PRSTDF]?$')
 
     def _search_notmuch(self, querystring):
         gmail = {}


### PR DESCRIPTION
Some MUAs store various flags at the end of the name of the emails,
i.e. the flag S "seen". This patch takes this into account when
attempting to extract the gmail ID.

Signed-off-by: Simon Chopin <simon.chopin@canonical.com>