### PR TITLE
gapi: Poll 10x when a call times out

### DIFF
--- a/notmuch_gmail/gapi.py
+++ b/notmuch_gmail/gapi.py
@@ -368,3 +368,9 @@ class GmailAPI(object):
                     raise
                 pause = 1 + pause * 2
                 LOG.debug('Connection error: %s', e)
+            except TimeoutError as e:
+                conn_errors += 1
+                if conn_errors > 10:
+                    raise
+                pause = 1 + pause * 2
+                LOG.debug('Timeout error: %s', e)

--- a/notmuch_gmail/gapi.py
+++ b/notmuch_gmail/gapi.py
@@ -351,7 +351,8 @@ class GmailAPI(object):
                 conn_errors = 0
 
             except HttpError as e:
-                if e.resp.status in (403, 429):
+                # 5xx per https://developers.google.com/analytics/devguides/reporting/core/v3/errors#handling_500_or_503_responses
+                if e.resp.status in (403, 429, 500, 503):
                     good_batches = 0
                     # increase pause duration before new batch
                     pause = min(1 + pause * 2, 30)


### PR DESCRIPTION
Currently, a TimeoutError from the REST API will terminate the program. This change causes TimeoutErrors to be treated consistently with other retriable errors.